### PR TITLE
Update Message.php

### DIFF
--- a/setup/simplesamlphp/simplesamlphp/modules/saml/lib/Message.php
+++ b/setup/simplesamlphp/simplesamlphp/modules/saml/lib/Message.php
@@ -647,14 +647,14 @@ class Message
         $inResponseTo = $response->getInResponseTo();
         
         /* SPID-PHP CUSTOM: strip spid-php */
-        $stateID = substr($inResponseTo, 8);
+        /*$stateID = substr($inResponseTo, 8);
         
         $state = State::loadState($stateID, 'saml:sp:sso', true);
         if($state==null) {
             throw new SSP_Error\Exception(
                 'State not found for ID '.$inResponseTo
             );
-        }
+        }*/
 
         /* END SPID CUSTOM */
 


### PR DESCRIPTION
Rimosso il controllo effettuato con il metodo loadState(), presente già in fase di verifica della Response (saml2-acs.php righe da 75 a 86).
L'aggiornamento evita il presentarsi dell'eccezione "State not found for ID".