### PR TITLE
Encrypt/Decrypt RelayState 

### DIFF
--- a/setup/simplesamlphp/saml2/src/SAML2/HTTPArtifact.php
+++ b/setup/simplesamlphp/saml2/src/SAML2/HTTPArtifact.php
@@ -175,7 +175,7 @@ class HTTPArtifact extends Binding
             $globalConfig = Configuration::getInstance();
             $secretSalt = $globalConfig->getString('secretsalt');
 
-            $encryptedRelayState = $_POST['RelayState'];
+            $encryptedRelayState = $_REQUEST['RelayState'];
 
             $ivSize = openssl_cipher_iv_length("aes-256-cbc");
             $decodedData = base64_decode($encryptedRelayState);

--- a/setup/simplesamlphp/saml2/src/SAML2/HTTPArtifact.php
+++ b/setup/simplesamlphp/saml2/src/SAML2/HTTPArtifact.php
@@ -58,8 +58,14 @@ class HTTPArtifact extends Binding
             'SAMLart' => $artifact,
         );
 
+        $globalConfig = Configuration::getInstance();
+        $secretSalt = $globalConfig->getString('secretsalt');
+
         $encryptedRelayState = $message->getRelayState();
-        $relayState = base64_encode(openssl_encrypt($encryptedRelayState, "aes-256-cbc", $message->getId()));
+
+        $ivSize = openssl_cipher_iv_length("aes-256-cbc");
+        $iv = openssl_random_pseudo_bytes($ivSize);
+        $relayState = base64_encode($iv . openssl_encrypt($encryptedRelayState, "aes-256-cbc", $secretSalt, 0, $iv));
 
         if ($relayState !== null) {
             $params['RelayState'] = $relayState;
@@ -166,13 +172,16 @@ class HTTPArtifact extends Binding
         $samlResponse->addValidator([get_class($this), 'validateSignature'], $artifactResponse);
 
         if (isset($_REQUEST['RelayState'])) {
-            $encryptedRelayState = $_REQUEST['RelayState'];
-            $relayState = openssl_decrypt(base64_decode($encryptedRelayState), "aes-256-cbc", $samlResponse->getId());
+            $globalConfig = Configuration::getInstance();
+            $secretSalt = $globalConfig->getString('secretsalt');
 
-            // if LogoutResponse
-            if($relayState==null) {
-                $relayState = openssl_decrypt(base64_decode($encryptedRelayState), "aes-256-cbc", $samlResponse->getInResponseTo());
-            }
+            $encryptedRelayState = $_POST['RelayState'];
+
+            $ivSize = openssl_cipher_iv_length("aes-256-cbc");
+            $decodedData = base64_decode($encryptedRelayState);
+            $iv = substr($decodedData, 0, $ivSize);
+
+            $relayState = openssl_decrypt(substr($decodedData, $ivSize), "aes-256-cbc", $secretSalt, 0, $iv);
 
             $samlResponse->setRelayState($relayState);
         }

--- a/setup/simplesamlphp/simplesamlphp/lib/SimpleSAML/Metadata/SAMLBuilder.php
+++ b/setup/simplesamlphp/simplesamlphp/lib/SimpleSAML/Metadata/SAMLBuilder.php
@@ -777,7 +777,7 @@ class SAMLBuilder
         $ext_dom = \SAML2\DOMDocumentFactory::create();
 
 
-        if($details['spid']) {
+        if(isset($details['spid'])) {
             if($details['spid.codeType']=='IPACode') {
                 $ext_elem_code = $ext_dom->createElementNS('https://spid.gov.it/saml-extensions', 'spid:IPACode', $details['spid.codeValue']);
                 $ext_elem_type = $ext_dom->createElementNS('https://spid.gov.it/saml-extensions', 'spid:Public', '');
@@ -801,7 +801,7 @@ class SAMLBuilder
         }
 
         // SPID Avviso n.29 v.3 - Private
-        if($details['fpa']) {
+        if(isset($details['fpa'])) {
             $ext_elem_IdPaese = $ext_dom->createElementNS('https://spid.gov.it/invoicing-extensions', 'fpa:IdPaese', $details['fpa.IdPaese']);
             $ext_elem_IdCodice = $ext_dom->createElementNS('https://spid.gov.it/invoicing-extensions', 'fpa:IdCodice', $details['fpa.IdCodice']);
 


### PR DESCRIPTION
Ciao @damikael,

ho modificato la parte di crittazione e decrittazione del RelayState. In realtà non mi è ben chiaro perché sia presente questa funzionalità: non vuoi che venga specificato nella query-string o nei dati di post in chiaro? Perché? 
Con la funzionalità che hai pensato sto riscontrando problemi nel logout dall'IdP di Poste mentre con l'IdP di test e il Validator tutto sembra funzionare correttamente. 

La modifica consiste nell'usare una password fissa per l'encrypt e il decrypt del RelayState piuttosto che l'id del message o il inResponseTo (Poste sembra rispondere con un inResponseTo incosistente al logout). 

Ho pensato di usare il "secretsalt" messo a disposizione da SimpleSAMLphp come password. Nella mia installazione ho modificato il secretsalt direttamente nel file si configurazione di SSP, l'ideale sarebbe configurarlo nello script composer tramite Setup.php.