### PR TITLE
set the hasColorSupport field in the Colors constructor

### DIFF
--- a/setup/Colors.php
+++ b/setup/Colors.php
@@ -37,7 +37,7 @@ class Colors
         $this->background_colors['cyan'] = '46';
         $this->background_colors['light_gray'] = '47';
 
-        $colors_supported = $this->hasColorSupport();
+        $this->hasColorSupport = $this->hasColorSupport();
     }
 
     // Returns colored string


### PR DESCRIPTION
The field is used to make the `hasColorSupport()` method exit early
if support for colors has already been determined. If the field is not
set, the fast path is never used.