### PR TITLE
prompt to backup log file simplesamlphp.log on uninstall

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -1268,6 +1268,31 @@ class Setup {
                 $serviceName = $_serviceName;
             }
         }
+		
+		if (file_exists("{$installDir}/vendor/simplesamlphp/simplesamlphp/log/simplesamlphp.log")) {
+			$scelta = "NOT_SET";
+			$logbackupdirname = "log-backup";
+			while($scelta != "Y" && $scelta != "N"){ 
+				echo "\nBackup simplesamlphp.log file in {$logbackupdirname} folder? [" .
+					$colors->getColoredString("Y", "green") . "/n]: ";
+					$scelta = strtoupper(readline());
+					if ($scelta == null || $scelta == "") { 
+						$scelta ="Y";
+					}
+			}
+			if($scelta == "Y"){
+				if (!file_exists("{$installDir}/{$logbackupdirname}")) {
+					echo $colors->getColoredString("\nLog backup directory not found. Making directory [" .
+							"{$installDir}/{$logbackupdirname}]... ", "white");
+					$filesystem->mkdir("{$installDir}/{$logbackupdirname}");
+					echo $colors->getColoredString("OK", "green");
+				}	
+				$now = new \DateTime("now");
+				echo $colors->getColoredString("\nMove simplesaml log into {$logbackupdirname} directory... ", "white");
+				$filesystem->rename("{$installDir}/vendor/simplesamlphp/simplesamlphp/log/simplesamlphp.log", "{$installDir}/{$logbackupdirname}/simplesamlphp-{$now->format( 'Ymd-His' )}.log");
+				echo $colors->getColoredString("OK", "green");
+			}
+		}
 
         echo $colors->getColoredString("\nRemove vendor directory [" .
                 $installDir . "]... ", "white");


### PR DESCRIPTION
Aggiunta la possibilità, tramite prompt con scelta, di eseguire lo spostamento dei log di simplesaml in caso di esecuzione comando `composer uninstall` lanciato per un aggiornamento del codice, in modo da salvarli in una cartella dedicata all'interno della `installDir` prima della cancellazione della cartella `vendor`.

Se il file esiste, chiedo se eseguirne il backup ed in caso affermativo:
1. Se la cartella non esiste la crea
2.  Sposto il file simplesamlphp.log nella cartella e lo rinomino con data e ora per evitare sovrascritture