### PR TITLE
Readline replacement

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -6,6 +6,15 @@ use Composer\Script\Event;
 use SPID_PHP\Colors;
 use Symfony\Component\Filesystem\Filesystem;
 
+// readline replacement
+if (!function_exists('readline')) {
+  function readline() {
+    $fp = fopen("php://stdin", "r");
+    $line = rtrim(fgets($fp, 1024));
+    return $line;
+  }
+}
+
 class Setup {
 
     public static function setup(Event $event) {


### PR DESCRIPTION
La funzione *readline* non è presente in tutte le installazioni del PHP. In particolare, le installazioni su localhost di XAMPP per linux non la prevedono e non permettono di aggiungerla successivamente.

Si rende necessaria quindi questa semplice patch per risolvere l'eventuale problema e rendere lo script di uso più generale.