### PR TITLE
removed 3 hiddenb bytes before php open tag

### DIFF
--- a/setup/config/authsources_public.tpl
+++ b/setup/config/authsources_public.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 $config = array(
     'admin' => array(


### PR DESCRIPTION
Rimozione nel template base per la creazione del metadata delle pubbliche amministrazioni di 3 byte con ascii code non visibile presenti prima dell'apertura del tag php che causavano un errore nel log ad ogni chiamata:

__simplesamlphp WARNING [.....] The configuration file '.../vendor/simplesamlphp/simplesamlphp/config/authsources.php' generates output. Please review your configuration_._

dovuto al controllo in simplesamlphp del fatto che alla require di un file di configurazione sia presente output.