### PR TITLE
Instructions for "snakeoil" certificate - Istruzioni per il certificato "snakeoil"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ Se nella directory locale sono presenti i file *spid-php-setup.json* e *spid-php
 Per utilizzare SimpleSAMLphp su webserver nginx occorre configurare nginx come nell'esempio seguente.
 In *myservice* inserire il nome del servizio come specificato durante l'installazione.
 
+### Prerequisiti per certificati self-signed
+Per fare valido l'uso del `snippets/snakeoil.conf` file su Nginx, è necessario generare il certificato "sel-signed" `/etc/ssl/certs/ssl-cert-snakeoil.pem`  attraverso la installazione del package `ssl-cert` su distribuizioni Debian based (come Ubuntu), con il comando:
+
+```bash
+sudo apt-get install ssl-cert
+```
+
+O, in alternativa, generare il certificato manualmente tramite OpenSSL, con il comando:
+
+```bash
+sudo make-ssl-cert generate-default-snakeoil --force-overwrite
+```
+
+### Configurazione
 ```
 server {  
   listen 443 ssl http2;  


### PR DESCRIPTION
When using Nginx, the `snippets/snakeoil.conf` configuration file expects that `/etc/ssl/certs/ssl-cert-snakeoil.pem` already exists, otherwise Nginx will not work.

This PR adds the instruction about adding them on Debian based, be it through `ssl-cert` on Debian and Debian based distros, as well as manually with OpenSSL certificate generator.

Solves #155 

---

Quando si utilizza Nginx, il file di configurazione `snippets/snakeoil.conf` prevede che `/etc/ssl/certs/ssl-cert-snakeoil.pem` esista già, altrimenti Nginx non funzionerà.

Questo PR aggiunge le istruzioni per crearli su Debian e distribuzioni basate su Debian, tramite `ssl-cert`, o manualmente con il generatore di certificati di OpenSSL.

Risolve #155 