### PR TITLE
Only one AuthnContexClassRef element MUST be present

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -47,6 +47,7 @@ class Setup {
         $_entityID = "https://localhost";
         $_spDomain = "localhost";
         $_acsIndex = 0;
+        $_spidLevel = 1;
         $_adminPassword = "admin";
         $_secretsalt = bin2hex(random_bytes(16)); 
         $_technicalContactName = "";
@@ -109,6 +110,19 @@ class Setup {
             if ($config['serviceName'] == null || $config['serviceName'] == "") {
                 $config['serviceName'] = $_serviceName;
             }
+        }
+
+        if (!isset($config['spidLevel'])) {
+            $scelta = ""
+            while ($scelta != "1" && $scelta != "2" && $scelta != "3") { 
+                echo "Please insert the SPID Level (" .
+                $colors->getColoredString("1", "green") . ", 2, 3): ";
+                $scelta = strtoupper(readline());
+                if ($scelta == null || $scelta == "") { 
+                    $scelta = "1";
+                }
+            }
+            $config['spidLevel'] = $scelta;
         }
 
         if (!isset($config['entityID'])) {
@@ -867,6 +881,7 @@ class Setup {
             "{{ORGANIZATIONCODE}}" => "'" . $config['spOrganizationCode'] . "'",
             "{{ORGANIZATIONEMAILADDRESS}}" => "'" . $config['spOrganizationEmailAddress'] . "'",
             "{{ORGANIZATIONTELEPHONENUMBER}}" => "'" . $config['spOrganizationTelephoneNumber'] . "'",
+            "{{SPIDLEVEL}}" => "'https://www.spid.gov.it/SpidL" . $config['spidLevel'] . "'"
         );
 
         if(!$config['spIsPublicAdministration']) {

--- a/setup/config/authsources_private.tpl
+++ b/setup/config/authsources_private.tpl
@@ -32,9 +32,7 @@ $config = array(
         /* Impostare il livello di spid che si vuole (1,2,3)  per il servizio */
         'AuthnContextClassRef' =>
         array(
-            'https://www.spid.gov.it/SpidL1',
-            'https://www.spid.gov.it/SpidL2',
-            'https://www.spid.gov.it/SpidL3'
+            {{SPIDLEVEL}}
         ),
 
         'AuthnContextComparison' => 'exact',

--- a/setup/config/authsources_public.tpl
+++ b/setup/config/authsources_public.tpl
@@ -32,9 +32,7 @@ $config = array(
         /* Impostare il livello di spid che si vuole (1,2,3)  per il servizio */
         'AuthnContextClassRef' =>
         array(
-            'https://www.spid.gov.it/SpidL1',
-            'https://www.spid.gov.it/SpidL2',
-            'https://www.spid.gov.it/SpidL3'
+            {{SPIDLEVEL}}
         ),
 
         'AuthnContextComparison' => 'exact',


### PR DESCRIPTION
In fase di validazione della Request tramite https://demo.spid.gov.it/validator viene restituito l'errore 40 Only one AuthnContexClassRef element MUST be present.

La procedura di setup genera il file authsources.php con il campo 'AuthnContextClassRef' = array(
            'https://www.spid.gov.it/SpidL1',
            'https://www.spid.gov.it/SpidL2',
            'https://www.spid.gov.it/SpidL3'
)

La Pull Request permette all'utente di scegliere, in fase di setup, il livello SPID (default 1) da associare al servizio.